### PR TITLE
New parameter for support of Content-Security-Policy nonce

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ Add field with type `RecaptchaType` to your form, example:
 
 `->add('captcha', RecaptchaType::class)`
 
+Options available : 
+
+``` 
+->add('captcha', RecaptchaType::class, [
+	 'script_nonce_csp' => $nonce
+])
+```
+
+- script_nonce_csp : Nonce for Content-Security-Policy header
+
 #### TODO
 1. Support for version v2
 2. Waiting for suggestions :)

--- a/src/Form/Type/RecaptchaType.php
+++ b/src/Form/Type/RecaptchaType.php
@@ -43,7 +43,7 @@ final class RecaptchaType extends AbstractType
             'pr_recaptcha_public_key' => $this->publicKey,
             'pr_recaptcha_hide_badge' => $this->hideBadge,
             'pr_recaptcha_host' => $this->host,
-            'script_nonce_csp' => $options['script_nonce_csp']
+            'script_nonce_csp' => $options['script_nonce_csp'] ?? ''
         ]);
     }
 

--- a/src/Form/Type/RecaptchaType.php
+++ b/src/Form/Type/RecaptchaType.php
@@ -42,7 +42,8 @@ final class RecaptchaType extends AbstractType
         $view->vars = array_replace($view->vars, [
             'pr_recaptcha_public_key' => $this->publicKey,
             'pr_recaptcha_hide_badge' => $this->hideBadge,
-            'pr_recaptcha_host' => $this->host
+            'pr_recaptcha_host' => $this->host,
+            'script_nonce_csp' => $options['script_nonce_csp']
         ]);
     }
 
@@ -57,8 +58,11 @@ final class RecaptchaType extends AbstractType
             'constraints' => [
                 new ContainsRecaptcha()
             ],
-            'validation_groups' => [ 'Default' ]
+            'validation_groups' => [ 'Default' ],
+            'script_nonce_csp' => ''
         ]);
+
+        $resolver->setAllowedTypes('script_nonce_csp', 'string');
     }
 
     /**

--- a/src/Resources/views/Form/recaptcha.html.twig
+++ b/src/Resources/views/Form/recaptcha.html.twig
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="{{ asset('/bundles/prrecaptcha/css/recaptcha.css') }}">
     {% endif %}
 
-    <script>
+    <script {% if form.vars.script_nonce_csp is defined %}nonce="{{ form.vars.script_nonce_csp }}"{% endif %}>
         grecaptcha.ready(function () {
             grecaptcha.execute('{{ form.vars.pr_recaptcha_public_key }}', { action: 'form' }).then(function (token) {
                 var recaptchaResponse = document.getElementById('{{ id }}');

--- a/tests/Form/Type/RecaptchaTypeTest.php
+++ b/tests/Form/Type/RecaptchaTypeTest.php
@@ -67,7 +67,8 @@ final class RecaptchaTypeTest extends TestCase
             'constraints' => [
                 new ContainsRecaptcha()
             ],
-            'validation_groups' => ['Default']
+            'validation_groups' => ['Default'],
+            'script_nonce_csp' => ''
         ];
 
         $this->assertEquals($expected, $options);


### PR DESCRIPTION
I added a new parameter for support of Content-Security-Policy nonce. 

The CSP header is used to prevent XSS attack. Nonce can be used to specify which script can be executed inline.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src

```
$form = $this->createFormBuilder()->add('captcha', RecaptchaType::class, [
            'script_nonce_csp' => $nonce
        ])->getForm();
```

Do not hesitate if there is anything that needs to be improved.