### PR TITLE
Add the possibility to define a custom form action name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 /vendor/
 composer.lock
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Recaptcha v3 bundle for Symfony
 
 [![Build Status](https://travis-ci.org/prugala/PRRecaptchaBundle.svg?branch=master)](https://travis-ci.org/prugala/PRRecaptchaBundle)
 
-#### Instalation
+#### Installation
 `composer require prugala/recaptcha-bundle`
 
 Register bundle in `AppKernel.php` file:
@@ -15,7 +15,7 @@ Register bundle in `AppKernel.php` file:
 ```new PR\Bundle\RecaptchaBundle\PRRecaptchaBundle()```
 
 #### Configuration
-```
+``` yaml
 pr_recaptcha:
     public_key: 'public key'
     secret_key: 'secret key'
@@ -36,15 +36,17 @@ Add field with type `RecaptchaType` to your form, example:
 
 `->add('captcha', RecaptchaType::class)`
 
-Options available : 
+Options available: 
 
-``` 
+``` php
 ->add('captcha', RecaptchaType::class, [
-	 'script_nonce_csp' => $nonce
+    'script_nonce_csp' => $nonce,
+    'action_name' => 'contact_form'
 ])
 ```
 
-- script_nonce_csp : Nonce for Content-Security-Policy header
+- script_nonce_csp: Nonce for Content-Security-Policy header
+- action_name: Form specific action name
 
 #### TODO
 1. Support for version v2

--- a/src/Form/Type/RecaptchaType.php
+++ b/src/Form/Type/RecaptchaType.php
@@ -59,10 +59,12 @@ final class RecaptchaType extends AbstractType
                 new ContainsRecaptcha()
             ],
             'validation_groups' => [ 'Default' ],
-            'script_nonce_csp' => ''
+            'script_nonce_csp' => '',
+            'action_name' => 'form',
         ]);
 
         $resolver->setAllowedTypes('script_nonce_csp', 'string');
+        $resolver->setAllowedTypes('action_name', 'string');
     }
 
     /**

--- a/src/Resources/views/Form/recaptcha.html.twig
+++ b/src/Resources/views/Form/recaptcha.html.twig
@@ -7,7 +7,7 @@
 
     <script {% if form.vars.script_nonce_csp is defined %}nonce="{{ form.vars.script_nonce_csp }}"{% endif %}>
         grecaptcha.ready(function () {
-            grecaptcha.execute('{{ form.vars.pr_recaptcha_public_key }}', { action: 'form' }).then(function (token) {
+            grecaptcha.execute('{{ form.vars.pr_recaptcha_public_key }}', { action: {{ form.vars.action_name|default('form') }} }).then(function (token) {
                 var recaptchaResponse = document.getElementById('{{ id }}');
                 recaptchaResponse.value = token;
             });

--- a/tests/Form/Type/RecaptchaTypeTest.php
+++ b/tests/Form/Type/RecaptchaTypeTest.php
@@ -68,7 +68,8 @@ final class RecaptchaTypeTest extends TestCase
                 new ContainsRecaptcha()
             ],
             'validation_groups' => ['Default'],
-            'script_nonce_csp' => ''
+            'script_nonce_csp' => '',
+            'action_name' => 'form',
         ];
 
         $this->assertEquals($expected, $options);


### PR DESCRIPTION
The title says it all. Enables to differentiate between the forms on your website.
![google_recaptcha_action_name](https://user-images.githubusercontent.com/17384333/71265085-ca2ec600-2345-11ea-9e04-6b6f91a8d603.png)

Default value stil is `form`.