### PR TITLE
[Bugfix] Pass action name option as var to view and quote action name

### DIFF
--- a/src/Form/Type/RecaptchaType.php
+++ b/src/Form/Type/RecaptchaType.php
@@ -43,7 +43,8 @@ final class RecaptchaType extends AbstractType
             'pr_recaptcha_public_key' => $this->publicKey,
             'pr_recaptcha_hide_badge' => $this->hideBadge,
             'pr_recaptcha_host' => $this->host,
-            'script_nonce_csp' => $options['script_nonce_csp'] ?? ''
+            'script_nonce_csp' => $options['script_nonce_csp'] ?? '',
+            'action_name' => $options['action_name'] ?? '',
         ]);
     }
 

--- a/src/Resources/views/Form/recaptcha.html.twig
+++ b/src/Resources/views/Form/recaptcha.html.twig
@@ -7,7 +7,7 @@
 
     <script {% if form.vars.script_nonce_csp is defined %}nonce="{{ form.vars.script_nonce_csp }}"{% endif %}>
         grecaptcha.ready(function () {
-            grecaptcha.execute('{{ form.vars.pr_recaptcha_public_key }}', { action: {{ form.vars.action_name|default('form') }} }).then(function (token) {
+            grecaptcha.execute('{{ form.vars.pr_recaptcha_public_key }}', { action: '{{ form.vars.action_name|default('form') }}' }).then(function (token) {
                 var recaptchaResponse = document.getElementById('{{ id }}');
                 recaptchaResponse.value = token;
             });


### PR DESCRIPTION
Sorry, I messed up. My previous PR wasn't very well tested. I forgot to pass the option `action_name` as variable to the view and the action name also has to be quoted in the output JavaScript.

Now this was properly tested on one of my projects and should be ready to use.